### PR TITLE
change zeta to use .size and add possibility of delta parameter

### DIFF
--- a/fvm/Continuation.py
+++ b/fvm/Continuation.py
@@ -238,8 +238,8 @@ class Continuation:
         mu = start
 
         # Set some parameters
-        self.delta = 1
-        self.zeta = 1 / len(x)
+        self.delta = self.parameters.get('Delta', 1)
+        self.zeta = 1 / x.size
 
         # Get the initial tangent (2.2.5 - 2.2.7).
         self.interface.set_parameter(parameter_name, mu + self.delta)


### PR DESCRIPTION
len(x) corresponds to the size of the first dimension, while .size returns the size of the array (=all elements). Also this PR adds the possibility of using Delta from parameters (with default =1 ), this should be no regret